### PR TITLE
Simplify registering multiple files for browserify

### DIFF
--- a/_resources/src/build/js.js
+++ b/_resources/src/build/js.js
@@ -15,8 +15,13 @@ var bytediff = require('gulp-bytediff');
 	By default this processor runs browserify, jshint, and if in prod mode uglify over a set of source JS files
 **/
 var config = {
-	jsSourcePath: 'js/**/*.js', /* where to read JS files to build from (footer) NOTE: this should be one file most likely */
-	jsHeaderSourcePath: 'js/header.js', /* these JS files go in the header */
+	/* 
+		where to read JS files to build from (can be an array)
+		NOTE: you probably do not want every single JS file here, since you
+		should be using Browserify to manage your depenedencies. Only
+		include discrete files that you need here.
+	 */
+	jsSourcePath: ['js/global.js', 'js/header.js'], 
 	jsWatchGlob: 'js/**', /* JS file pattern to watch for changes when in watch mode */
 	jsOutputPath: '../js', /* where to emit the processed files */
 	
@@ -48,16 +53,10 @@ module.exports = function(gulp) {
 	gulp.task('js-dev', ['js-clean'], function() {	
 		createJsStream(gulp, config.jsSourcePath, true)
 			.pipe(gulp.dest(config.jsOutputPath));
-
-		createJsStream(gulp, config.jsHeaderSourcePath, true)
-			.pipe(gulp.dest(config.jsOutputPath));
 	});
 	
 	gulp.task('js-production', ['js-clean'], function() {
 		createProductionJsStream(gulp, config.jsSourcePath, false)
-			.pipe(gulp.dest(config.jsOutputPath));
-
-		createProductionJsStream(gulp, config.jsHeaderSourcePath, false)
 			.pipe(gulp.dest(config.jsOutputPath));
 	});
 	
@@ -79,10 +78,6 @@ module.exports = function(gulp) {
 	gulp._watchTasks.push(function(gulp, liveReloadServer) {
 		watch({ glob: config.jsWatchGlob, emitOnGlob:false, name: 'JSWatcher' }, function(changedFiles) {
 			createJsStream(gulp, config.jsSourcePath, true)
-				.pipe(gulp.dest(config.jsOutputPath))
-				.pipe(livereload(liveReloadServer));
-
-			createJsStream(gulp, config.jsHeaderSourcePath, true)
 				.pipe(gulp.dest(config.jsOutputPath))
 				.pipe(livereload(liveReloadServer));
 		});


### PR DESCRIPTION
Removes dupe code for the header and uses array registration instead.
