### PR TITLE
Switch to using rimraf instead of the deprecated gulp-clean

### DIFF
--- a/_resources/src/build/css.js
+++ b/_resources/src/build/css.js
@@ -1,7 +1,7 @@
 /*global require, module */
 'use strict';
 
-var clean = require('gulp-clean');
+var rimraf = require('rimraf');
 var concat = require('gulp-concat');
 var sass = require('gulp-sass');
 var cssmin = require('gulp-minify-css');
@@ -10,7 +10,6 @@ var cmq = require('gulp-combine-media-queries');
 var plumber = require('gulp-plumber');
 var watch = require('gulp-watch');
 var livereload = require('gulp-livereload');
-//var bytediff = require('gulp-bytediff');
 var stylestats = require('gulp-stylestats');
 
 /**
@@ -55,9 +54,7 @@ module.exports = function(gulp) {
 	
 	gulp.task('css-production', ['css-clean'], function() {
 		var sassStream = createSassStream(gulp)
-			//.pipe(bytediff.start())
-			.pipe(cssmin())
-			//.pipe(bytediff.stop());
+			.pipe(cssmin());
 		
 		emitCssStream(sassStream, gulp);
 	});
@@ -69,9 +66,8 @@ module.exports = function(gulp) {
 			.pipe(stylestats());
 	});
 	
-	gulp.task('css-clean', function() {
-		return gulp.src(config.cssOutputPath, {read:false})
-			.pipe(clean({force:true}));
+	gulp.task('css-clean', function(cb) {
+		rimraf(config.cssOutputPath, cb);
 	});
 	
 	gulp._watchTasks = gulp._watchTasks || [];

--- a/_resources/src/build/fonts.js
+++ b/_resources/src/build/fonts.js
@@ -1,7 +1,7 @@
 /*global require, module */
 'use strict';
 
-var clean = require('gulp-clean');
+var rimraf = require('rimraf');
 var plumber = require('gulp-plumber');
 var newer = require('gulp-newer');
 var imagemin = require('gulp-imagemin');
@@ -48,9 +48,8 @@ module.exports = function(gulp) {
 			.pipe(gulp.dest(config.fontOutputPath));
 	});
 
-	gulp.task('fonts-clean', function() {
-		return gulp.src(config.fontOutputPath, {read:false})
-			.pipe(clean({force:true}));
+	gulp.task('fonts-clean', function(cb) {
+		rimraf(config.fontOutputPath, cb);
 	});
 	
 	gulp._watchTasks = gulp._watchTasks || [];

--- a/_resources/src/build/img.js
+++ b/_resources/src/build/img.js
@@ -1,7 +1,7 @@
 /*global require, module */
 'use strict';
 
-var clean = require('gulp-clean');
+var rimraf = require('rimraf');
 var plumber = require('gulp-plumber');
 var newer = require('gulp-newer');
 var imagemin = require('gulp-imagemin');
@@ -49,9 +49,8 @@ module.exports = function(gulp) {
 			.pipe(gulp.dest(config.imageOutputPath));
 	});
 
-	gulp.task('img-clean', function() {
-		return gulp.src(config.imageOutputPath, {read:false})
-			.pipe(clean({force:true}));
+	gulp.task('img-clean', function(cb) {
+		rimraf(config.imageOutputPath, cb);
 	});
 	
 	gulp._watchTasks = gulp._watchTasks || [];

--- a/_resources/src/build/js.js
+++ b/_resources/src/build/js.js
@@ -1,7 +1,7 @@
 /*global require, module */
 'use strict';
 
-var clean = require('gulp-clean');
+var rimraf = require('rimraf');
 var plumber = require('gulp-plumber');
 var watch = require('gulp-watch');
 var livereload = require('gulp-livereload');
@@ -79,9 +79,8 @@ module.exports = function(gulp) {
 			.pipe(jshint.reporter('jshint-stylish'));
 	});
 	
-	gulp.task('js-clean', function() {
-		return gulp.src(config.jsOutputPath, {read:false})
-			.pipe(clean({force:true}));
+	gulp.task('js-clean', function(cb) {
+		rimraf(config.jsOutputPath, cb);
 	});
 	
 	/* Uncomment (and add to tasks in the gulpfile) if using YUIdoc for JS

--- a/_resources/src/package.json
+++ b/_resources/src/package.json
@@ -5,9 +5,10 @@
 	"repository": "none",
 	"devDependencies": {
 		"tiny-lr": "~0.0.7",
+		"rimraf": "~2.2.8",
+		
 		"gulp": "~3.6.2",
 		"gulp-concat": "~2.2.0",
-		"gulp-clean": "~0.3.0",
 		"gulp-util": "~2.2.14",
 		"gulp-plumber": "~0.6.2",
 		"gulp-newer": "~0.3.0",


### PR DESCRIPTION
This seems to be more reliable, as I was having issues with gulp-clean terminating the pipeline for no apparent reason.
