### PR TITLE
Changing font-size declaration to be an integer rather than a percentage

### DIFF
--- a/Assets/src/scss/variables/_typography.scss
+++ b/Assets/src/scss/variables/_typography.scss
@@ -2,11 +2,11 @@
 
 // @function typography
 // The base typography settings for the project.
-// @param $baseFontPercentage {Number} The percentage of the font-size to be used on the root html element.  [percentage]
-// @param $baseFontSize {Number} The base font-size for the root html element, calculated as an integer based on $baseFontPercentage.  [integer]
+// @param $baseFontSize {Number} The base font-size for the root html element.  [integer]
+// @param $baseFontPercentage {Number} The percentage of the font-size to be used on the root html element, calculated based on $baseFontSize.  [percentage]
 // @param $lineHeight {Number} The base line height for the root html element.  [decimal]
 // @param $baseFontFamily {String} The base font-family for the root html element.
-$baseFontPercentage: 100%;
-$baseFontSize: 16 * ($baseFontPercentage / 100%);
+$baseFontSize: 16;
+$baseFontPercentage: percentage($baseFontSize / 16);
 $lineHeight: 1.5;
 $baseFontFamily: 'Source Sans Pro', Helvetica, Arial, sans-serif;


### PR DESCRIPTION
Font-size used to be declared by altering the `$baseFontPercentage` variable.  I've changed this so you set the `$baseFontSize` as an integer instead.  This is much clearer than using a percentage (e.g. you set it to 14 instead of 87.5%).
