### PR TITLE
Add `!important` to active tab panel display

### DIFF
--- a/Assets/src/css/modules/_responsive-tabs.scss
+++ b/Assets/src/css/modules/_responsive-tabs.scss
@@ -105,7 +105,8 @@ $tabPanelTextColor: black;
 		display: none;
 
 		@include respond(breakpointMedium) {
-			display: block;
+			// !important to fight inline display:none set in js
+			display: block !important;
 		}
 	}
 


### PR DESCRIPTION
When the tabs move from a tab layout down to the accordion layout, are interacted with then left in a state where all accordion fields are closed, and the window is then resized back up to the tab layout, no tab panes will are visible. 

Using `!important` here forces the active tab panel to display, overriding the inline `style: display:none;` leftover from the accordion interactions. `!important` is obviously ugly but the selector it’s on is _super_ specific (`.responsive-tabs__panel--closed-accordion-only`), so it’s almost certainly safe; it’s being used in place of several lines of javascript and therefore seems like a good tradeoff; and the original CSS source that ships with the plugin [uses `!important` in this same context](https://github.com/petelove666/Responsive-Tabs/blob/master/css/responsive-tabs.css#L14-L16) as well.
