### PR TITLE
Adds a variable for icon font family to variables/typography

### DIFF
--- a/Assets/src/css/variables/_typography.scss
+++ b/Assets/src/css/variables/_typography.scss
@@ -10,3 +10,4 @@ $baseFontSize: 16;
 $baseFontPercentage: percentage($baseFontSize / 16);
 $lineHeight: 1.5;
 $baseFontFamily: 'Source Sans Pro', Helvetica, Arial, sans-serif;
+$iconFont: 'icomoon';


### PR DESCRIPTION
I realize this adds a variable that is longer (by one character) than what it is abstracting, but I found myself wanting it today while working on CTGR. Once literally, in that I used a non-existent variable and was appropriately scolded by gulp. I also looked a couple times today to see if `'iconmoon'` was capitalized in the `@font-face` declaration. My short-term memory could be better, I admit, but having this variable available would (likely) eliminate the need for guessing.
