### PR TITLE
Moves specific list styles from base/defaults into modules/lists

### DIFF
--- a/Assets/src/css/base/defaults/_lists.scss
+++ b/Assets/src/css/base/defaults/_lists.scss
@@ -1,6 +1,6 @@
 ul, ol {
 	margin: em(10) 0 0;
-	padding: 0 0 0 $gutterInPx;
+	padding: 0 0 0 em(20);
 
 	ul {
 		margin-left: em(18);

--- a/Assets/src/css/modules/_all.scss
+++ b/Assets/src/css/modules/_all.scss
@@ -3,6 +3,7 @@
 @import "callout";
 @import "fancybox";
 @import "forms";
+@import "lists";
 @import "navigation";
 @import "responsive-tabs";
 @import "tooltips";

--- a/Assets/src/css/modules/_lists.scss
+++ b/Assets/src/css/modules/_lists.scss
@@ -1,12 +1,8 @@
-.plain {
-	list-style-image: none;
-	list-style: none;
-	margin-left: 0;
-	text-align: left;
+// @category modules
 
-	.no-svg & {
-		list-style-image: none;
-		list-style: none;
-		margin: 0;
-	}
+// @function lists
+// Styles related to lists.
+.list-plain {
+	list-style: none;
+	padding-left: 0;
 }


### PR DESCRIPTION
Because the defaults are declared on the `<ul>` and `<ol>` tags, any classes qualifying those either need to be also tag-qualified, also declared inside this default file, or use `!important`. Those aren't great options. Moving these styles out into a modules file and only defining defaults on the naked `<ul>` and `<ol>` tags themselves allows any new classes to be extended more easily and work simultaneously on a single element without the ones declared in defaults _always_ overpowering the others.
