### PR TITLE
Automatically restart watch should something terminate it

### DIFF
--- a/Assets/src/build/build.cmd
+++ b/Assets/src/build/build.cmd
@@ -47,7 +47,11 @@ if %errorlevel% neq 0 (
 )
 
 REM this noretry flag is used to prevent the build from retrying npm install to fix itself more than once
-SET noretry=1
+REM (except for watches, which restart infinitely)
+
+if '%1' NEQ 'watch' (
+	SET noretry=1
+)
 GOTO :run_gulp
 
 :usage

--- a/Assets/src/build/build.sh
+++ b/Assets/src/build/build.sh
@@ -23,7 +23,7 @@ then
 	fi
 fi
 
-if [ "$1" == "watch" ];
+if [ "$1" != "watch" ];
 then
 	NORETRY=1
 fi


### PR DESCRIPTION
What the description says. If some misbehaving plugin terminates the node process, this automatically restarts it...forever.

Would love it if someone hacked the OSX .command file the same way.