### PR TITLE
Optional Parameters as Maps

### DIFF
--- a/Assets/src/css/base/defaults/_typography.scss
+++ b/Assets/src/css/base/defaults/_typography.scss
@@ -56,7 +56,7 @@ p, h2, h3, h4 {
 
 h1 {
 	@include font-size(44);
-	margin-top: em(28, 44);
+	margin-top: em(28, (context: 44));
 
 	small {
 		display: block;
@@ -64,15 +64,15 @@ h1 {
 }
 h2 {
 	@include font-size(36);
-	margin-top: em(28, 36);
+	margin-top: em(28, (context: 36));
 }
 h3 {
 	@include font-size(24);
-	margin-top: em(28, 24);
+	margin-top: em(28, (context: 24));
 }
 h4 {
 	@include font-size(14);
-	margin-top: em(28, 14);
+	margin-top: em(28, (context: 14));
 }
 
 h2, h3 {

--- a/Assets/src/css/base/defaults/_typography.scss
+++ b/Assets/src/css/base/defaults/_typography.scss
@@ -1,6 +1,6 @@
 a {
 	color: black;
-	@include transition(color);
+	@include transition((property: color));
 
 	&:hover,
 	&:active,

--- a/Assets/src/css/functions/_em.scss
+++ b/Assets/src/css/functions/_em.scss
@@ -9,13 +9,18 @@
 // =em(12) will return 0.75em
 // =em(12, 24) will return 0.5em
 // =em(12 18, 24) will return 0.5em 0.75em
-@function em($target, $context: $baseFontSize) {
-	@if type-of($target) == list {
+@function em($target, $options: ()) {
+	$options: map-merge((
+		context: $baseFontSize
+	), $options);
 
+	$context: map-get($options, context);
+
+	@if type-of($target) == list {
 		$output: unquote('') !default;
 
 		@each $value in $target {
-			$value: em($value, $context);
+			$value: em($value, (context: $context));
 
 			$output: append($output, $value);
 		}
@@ -25,7 +30,6 @@
 		$context: parseInt($context);
 
 		$output: ($target / $context) * 1em;
-
 	}
 
 	@return $output;

--- a/Assets/src/css/functions/_grid-calc.scss
+++ b/Assets/src/css/functions/_grid-calc.scss
@@ -8,7 +8,13 @@
 }
 
 // Return single column width
-@function oneColumn($includeGutterWidth: true) {
+@function oneColumn($options: ()) {
+	$options: map-merge((
+		includeGutterWidth: true
+	), $options);
+
+	$includeGutterWidth: map-get($options, includeGutterWidth);
+
 	@if $includeGutterWidth == true {
 		@return (100% - (($columns - 1) * $gutterWidth)) / $columns;
 	}
@@ -18,17 +24,29 @@
 }
 
 // Calculate Grid Column Widths
-@function columns($n, $includeGutterWidth: true){
+@function columns($n, $options: ()){
+	$options: map-merge((
+		includeGutterWidth: true
+	), $options);
+
+	$includeGutterWidth: map-get($options, includeGutterWidth);
+
 	@if $includeGutterWidth == true {
-		@return (oneColumn($includeGutterWidth) * $n) + ($gutterWidth * ($n - 1));
+		@return (oneColumn((includeGutterWidth: $includeGutterWidth)) * $n) + ($gutterWidth * ($n - 1));
 	}
 	@else {
-		@return oneColumn($includeGutterWidth) * $n;
+		@return oneColumn((includeGutterWidth: $includeGutterWidth)) * $n;
 	}
 }
 
 // Calculate Push Class Margins
-@function push_x($n, $firstChild: false) {
+@function push_x($n, $options: ()) {
+	$options: map-merge((
+		firstChild: false
+	), $options);
+
+	$firstChild: map-get($options, firstChild);
+
 	@if $firstChild == true {
 		@return columns($n) + $gutterWidth; // Column width + gutter
 	}

--- a/Assets/src/css/functions/_image.scss
+++ b/Assets/src/css/functions/_image.scss
@@ -3,12 +3,18 @@
 // @function image
 // Simplifies image import
 // @param $imageName {String} The image's filename.
-// @param $directory {String} The folder or path in which the image is found. Default value: $imagesFolder
+// @param $directory {String} The folder or path in which the image is found. Default value: $imagesFolder.
 // @return {String} The compiled url()
 // @usage
 // =image('feed.png') will return url('../img/css/feed.png') if $imagesFolder is '../img/css/'
-// =image('feed.png', '../img/css/') will return url('../img/css/feed.png')
-@function image($imageName, $directory: $imagesFolder) {
+// =image('feed.png', (directory: '../img/css/')) will return url('../img/css/feed.png')
+@function image($imageName, $options: ()) {
+	$options: map-merge((
+		directory: $imagesFolder
+	), $options);
+
+	$directory: map-get($options, directory);
+
 	$imageName: unquote($imageName);
 	$directory: unquote($directory);
 

--- a/Assets/src/css/layout/_content.scss
+++ b/Assets/src/css/layout/_content.scss
@@ -3,7 +3,7 @@
 // @function content
 // The location to define major column layouts for your main content area.
 .wrapper {
-	@include row(false, 0);
+	@include row((padding: 0));
 }
 
 // standard grid
@@ -47,7 +47,7 @@
 
 // complex layout
 .layout-complex-wrapper {
-	@include row(false, 0, 100%);
+	@include row((padding: 0, maxWidth: 100%));
 }
 
 .layout-complex-header {
@@ -118,7 +118,7 @@
 
 .nested,
 aside {
-	@include row(nested);
+	@include row((nested: nested));
 }
 
 .multi-grid {

--- a/Assets/src/css/layout/_content.scss
+++ b/Assets/src/css/layout/_content.scss
@@ -66,11 +66,11 @@
 	padding: $columnPadding;
 
 	@include media(breakpointMedium) {
-		width: columns(7, false);
+		width: columns(7, (includeGutterWidth: false));
 	}
 
 	@include media(breakpointLarge) {
-		width: columns(6, false);
+		width: columns(6, (includeGutterWidth: false));
 	}
 }
 
@@ -80,7 +80,7 @@
 	padding: $columnPadding;
 
 	@include media(breakpointExtraLarge) {
-		width: columns(1.5, false);
+		width: columns(1.5, (includeGutterWidth: false));
 	}
 }
 
@@ -90,11 +90,11 @@
 	padding: $columnPadding;
 
 	@include media(breakpointMedium) {
-		width: columns(5, false);
+		width: columns(5, (includeGutterWidth: false));
 	}
 
 	@include media(breakpointLarge) {
-		width: columns(3, false);
+		width: columns(3, (includeGutterWidth: false));
 	}
 }
 
@@ -103,11 +103,11 @@
 	padding: $columnPadding;
 
 	@include media(breakpointLarge) {
-		width: columns(3, false);
+		width: columns(3, (includeGutterWidth: false));
 	}
 
 	@include media(breakpointExtraLarge) {
-		width: columns(1.5, false);
+		width: columns(1.5, (includeGutterWidth: false));
 	}
 }
 

--- a/Assets/src/css/layout/_content.scss
+++ b/Assets/src/css/layout/_content.scss
@@ -17,7 +17,7 @@
 }
 
 .layout-primary-pushed {
-	@include column(6, true);
+	@include column(6, (shifted: true));
 	@include push(3, true);
 }
 
@@ -31,7 +31,7 @@
 }
 
 .layout-secondary-pulled {
-	@include column(3, true);
+	@include column(3, (shifted: true));
 	@include pull(6, 3);
 }
 
@@ -41,7 +41,7 @@
 }
 
 .layout-centered {
-	@include column(8, false, $columnPadding, false, centered);
+	@include column(8, (alignment: centered));
 	border: 1px dashed $colorPrimary;
 }
 

--- a/Assets/src/css/layout/_content.scss
+++ b/Assets/src/css/layout/_content.scss
@@ -113,7 +113,7 @@
 
 // supporting classes
 .map {
-	@include aspect-ratio((width: 4, height: 3));
+	@include aspect-ratio(4, 3);
 
 	img {
 		max-width: none; // resets map controls

--- a/Assets/src/css/layout/_content.scss
+++ b/Assets/src/css/layout/_content.scss
@@ -118,7 +118,7 @@
 
 .nested,
 aside {
-	@include row((nested: nested));
+	@include row((nested: true));
 }
 
 .multi-grid {

--- a/Assets/src/css/layout/_content.scss
+++ b/Assets/src/css/layout/_content.scss
@@ -113,7 +113,7 @@
 
 // supporting classes
 .aspect-ratio-4-3 {
-	@include aspect-ratio(4, 3);
+	@include aspect-ratio((width: 4, height: 3));
 }
 
 .nested,

--- a/Assets/src/css/layout/_content.scss
+++ b/Assets/src/css/layout/_content.scss
@@ -124,7 +124,7 @@ aside {
 .multi-grid {
 	border: 1px dashed $colorPrimary;
 
-	@include multi-grid("> li", 1, 2, 3, flush) {
+	@include multi-grid("> li", 1, 2, 3, (flush: true)) {
 		text-align: center;
 	}
 }

--- a/Assets/src/css/layout/_content.scss
+++ b/Assets/src/css/layout/_content.scss
@@ -18,7 +18,7 @@
 
 .layout-primary-pushed {
 	@include column(6, (shifted: true));
-	@include push(3, true);
+	@include push(3, (firstChild: true));
 }
 
 .layout-secondary,

--- a/Assets/src/css/mixins/_aspect-ratio.scss
+++ b/Assets/src/css/mixins/_aspect-ratio.scss
@@ -6,8 +6,16 @@
 // @param $height {Number} The desired height of the element's aspect ratio.  Default value: 9.  [px|integer]
 // @usage
 // =aspect-ratio()
-// =aspect-ratio(4, 3)
-@mixin aspect-ratio($width: 16, $height: 9) {
+// =aspect-ratio((width: 4, height: 3))
+@mixin aspect-ratio($options: ()) {
+	$options: map-merge((
+		width: 16,
+		height: 9
+	), $options);
+
+	$width: map-get($options, width);
+	$height: map-get($options, height);
+
 	height: 0;
 	padding-bottom: percentage(parseInt($height) / parseInt($width));
 	position: relative;

--- a/Assets/src/css/mixins/_aspect-ratio.scss
+++ b/Assets/src/css/mixins/_aspect-ratio.scss
@@ -2,20 +2,11 @@
 
 // @mixin aspect-ratio
 // Creates the necessary dimensions for an element to have a fixed aspect ratio.
-// @param $width {Number} The desired width of the element's aspect ratio.  Default value: 16.  [px|integer]
-// @param $height {Number} The desired height of the element's aspect ratio.  Default value: 9.  [px|integer]
+// @param $width {Number} The desired width of the element's aspect ratio.  [px|integer]
+// @param $height {Number} The desired height of the element's aspect ratio.  [px|integer]
 // @usage
-// =aspect-ratio()
-// =aspect-ratio((width: 4, height: 3))
-@mixin aspect-ratio($options: ()) {
-	$options: map-merge((
-		width: 16,
-		height: 9
-	), $options);
-
-	$width: map-get($options, width);
-	$height: map-get($options, height);
-
+// =aspect-ratio(16, 9)
+@mixin aspect-ratio($width, $height) {
 	position: relative;	// context for direct descendant
 
 	// container to maintain aspect ratio

--- a/Assets/src/css/mixins/_font-size.scss
+++ b/Assets/src/css/mixins/_font-size.scss
@@ -2,11 +2,10 @@
 
 // @mixin font-size
 // Outputs the desired font-size in rems with a px fallback.
-// @param $size {Number} The desired font-size in pixels or its integer equivalent.  Default value: $baseFontSize.  [px|integer]
+// @param $size {Number} The desired font-size in pixels or its integer equivalent.  [px|integer]
 // @usage
-// =font-size()
 // =font-size(12)
-@mixin font-size($size: $baseFontSize) {
+@mixin font-size($size) {
 	font-size: parseInt($size) + px;
 	font-size: rem($size);
 }

--- a/Assets/src/css/mixins/_gradients.scss
+++ b/Assets/src/css/mixins/_gradients.scss
@@ -2,21 +2,13 @@
 
 // @mixin gradient
 // Adds background color gradient support
-// @param $from {HexColor} The color to begin your gradient.  Default value: #000000.
-// @param $to {HexColor} The color to end your gradient.  Default value: #ffffff.
+// @param $from {HexColor} The color to begin your gradient.
+// @param $to {HexColor} The color to end your gradient.
 // @usage
-// = @include gradient((from: #000000, to: #ffffff));
-// = or even with variables and SCSS function @include gradient((from: $link-color, to: darken($link-color, 5%)));
+// = @include gradient(#000000, #ffffff);
+// = @include gradient($link-color, darken($link-color, 5%));
 
-@mixin gradient($options: ()) {
-	$options: map-merge((
-		from: #000000,
-		to: #ffffff
-	), $options);
-
-	$from: map-get($options, from);
-	$to: map-get($options, to);
-
+@mixin gradient($from, $to) {
 	background-color: $to; // All else fails
 	background-image: linear-gradient(to bottom, $from 0%, $to 100%);	// W3C
 	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#{$from}', endColorstr='#{$to}',GradientType=0 );	// IE6-9

--- a/Assets/src/css/mixins/_gradients.scss
+++ b/Assets/src/css/mixins/_gradients.scss
@@ -2,12 +2,21 @@
 
 // @mixin gradient
 // Adds background color gradient support
-// @param $from {HexColor} and $to {HexColor}. The colors from and to you would like to gradient between.
+// @param $from {HexColor} The color to begin your gradient.  Default value: #000000.
+// @param $to {HexColor} The color to end your gradient.  Default value: #ffffff.
 // @usage
-// = @include gradient(#000000, #ffffff); 
-// = or even with variables and SCSS function @include gradient($link-color, darken($link-color, 5%));
+// = @include gradient((from: #000000, to: #ffffff));
+// = or even with variables and SCSS function @include gradient((from: $link-color, to: darken($link-color, 5%)));
 
-@mixin gradient($from: #000000, $to: #ffffff) { //#000 & #fff are default colors.
+@mixin gradient($options: ()) {
+	$options: map-merge((
+		from: #000000,
+		to: #ffffff
+	), $options);
+
+	$from: map-get($options, from);
+	$to: map-get($options, to);
+
 	background-color: $to; // All else fails
 	background-image: linear-gradient(to bottom, $from 0%, $to 100%);	// W3C
 	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#{$from}', endColorstr='#{$to}',GradientType=0 );	// IE6-9

--- a/Assets/src/css/mixins/_media.scss
+++ b/Assets/src/css/mixins/_media.scss
@@ -7,11 +7,11 @@
 // =media(breakpointMedium)
 @mixin media($query) {
 	@if map-has-key($breakpoints, $query) {
-		@media only screen and (min-width: em(map-get($breakpoints, $query), 16)) { @content; }
+		@media only screen and (min-width: em(map-get($breakpoints, $query), (context: 16))) { @content; }
 	}
 
 	@if $query == rotateDevice {
-		@media only screen and (max-width: em(map-get($breakpoints, breakpointSmall), 16)) and (orientation: portrait) { @content; }
+		@media only screen and (max-width: em(map-get($breakpoints, breakpointSmall), (context: 16))) and (orientation: portrait) { @content; }
 	}
 
 	@if $query == print {

--- a/Assets/src/css/mixins/_retina-image.scss
+++ b/Assets/src/css/mixins/_retina-image.scss
@@ -9,9 +9,21 @@
 // @param $property {String} The CSS property to which you wish to apply the image.  Default value: background-image.
 // @usage
 // =retina-image(bullet-blue.png)
-// =retina-image(bullet-blue.png, 12px 12px)
-// =retina-image(bullet-blue.png, 12px 12px, '-2x')
-@mixin retina-image($imageName, $backgroundSize: 'none', $retinaFileSuffix: '@2x', $backgroundRepeat: no-repeat, $property: background-image) {
+// =retina-image(bullet-blue.png, (backgroundSize: 12px 12px))
+// =retina-image(bullet-blue.png, (retinaFileSuffix: '-2x'))
+@mixin retina-image($imageName, $options: ()) {
+	$options: map-merge((
+		backgroundSize: 'none',
+		retinaFileSuffix: '@2x',
+		backgroundRepeat: no-repeat,
+		property: background-image
+	), $options);
+
+	$backgroundSize: map-get($options, backgroundSize);
+	$retinaFileSuffix: map-get($options, retinaFileSuffix);
+	$backgroundRepeat: map-get($options, backgroundRepeat);
+	$property: map-get($options, property);
+
 	$imageNameRetina: str-insert($imageName, $retinaFileSuffix, -5);
 
 	#{$property}: image($imageName);

--- a/Assets/src/css/mixins/_rgba-background-color.scss
+++ b/Assets/src/css/mixins/_rgba-background-color.scss
@@ -4,11 +4,17 @@
 // Outputs an rgba background-color with an opaque fallback. If a PNG is supplied, it will be used as a fallback for older IEs, and opaque background will be overridden.  Note: modernizr is required for the PNG fallback.
 // @param $color {Color} The desired color.
 // @param $alpha {Number} The desired level of opacity. [Decimal]
-// @param $image {String} Filename and extension of a variable transparency fallback. Default value: false.
+// @param $image {String} Filename of a variable transparency fallback.  NOTE:  Does not include extension; it is assumed to be a PNG file. Default value: false.
 // @usage
 // =rgba-background-color(#ff0000, 0.2);
-// =rgba-background-color(red, 0.7, translucent-red);
-@mixin rgba-background-color($color, $alpha, $image: false) {
+// =rgba-background-color(red, 0.7, (image: translucent-red));
+@mixin rgba-background-color($color, $alpha, $options: ()) {
+	$options: map-merge((
+		image: false
+	), $options);
+
+	$image: map-get($options, image);
+
 	background-color: $color;
 	background-color: rgba($color, $alpha);
 

--- a/Assets/src/css/mixins/_svg-image.scss
+++ b/Assets/src/css/mixins/_svg-image.scss
@@ -6,8 +6,14 @@
 // @param $property {String} The CSS property to which you wish to apply the image.  Default value: background-image.
 // @usage
 // =svg-image(logo)
-// =svg-image(bullet-blue, list-style-image)
-@mixin svg-image($imageName, $property: background-image) {
+// =svg-image(bullet-blue, (property: list-style-image))
+@mixin svg-image($imageName, $options: ()) {
+	$options: map-merge((
+		property: background-image
+	), $options);
+
+	$property: map-get($options, property);
+
 	#{$property}: image('#{$imageName}.svg', $svgFolder);
 
 	.no-svg & {

--- a/Assets/src/css/mixins/_transition.scss
+++ b/Assets/src/css/mixins/_transition.scss
@@ -8,9 +8,21 @@
 // @param $delay {Number} The amount of time to delay the transition.  Default value: $transitionDelay.  [seconds]
 // @usage
 // =transition()
-// =transition(background-color)
-// =transition(background-color, 0.5s, ease-in-out)
-@mixin transition($property: all, $duration: $transitionDuration, $easing: $transitionEasing, $delay: $transitionDelay) {
+// =transition((property: background-color))
+// =transition((property: background-color, duration: 0.5s, easing: ease-in-out))
+@mixin transition($options: ()) {
+	$options: map-merge((
+		property: all,
+		duration: $transitionDuration,
+		easing: $transitionEasing,
+		delay: $transitionDelay
+	), $options);
+
+	$property: map-get($options, property);
+	$duration: map-get($options, duration);
+	$easing: map-get($options, easing);
+	$delay: map-get($options, delay);
+
 	@if (parseInt($delay) > 0) {
 		transition: $property $duration $easing $delay;
 	}

--- a/Assets/src/css/mixins/grid/_grid.scss
+++ b/Assets/src/css/mixins/grid/_grid.scss
@@ -114,7 +114,7 @@
 						margin-left: push_x($i);
 
 						&:first-child {
-							margin-left: push_x($i, true);
+							margin-left: push_x($i, (firstChild: true));
 						}
 					}
 				}

--- a/Assets/src/css/mixins/grid/_multi-grid.scss
+++ b/Assets/src/css/mixins/grid/_multi-grid.scss
@@ -31,7 +31,7 @@
 
 	// this is the container
 	@if $flush == true {
-		@include row((nested: nested));
+		@include row((nested: true));
 		margin: 0 (-1 * $padding);
 	}
 	@else {

--- a/Assets/src/css/mixins/grid/_multi-grid.scss
+++ b/Assets/src/css/mixins/grid/_multi-grid.scss
@@ -6,19 +6,33 @@
 // @param $smallColumns {Number} The number of columns to be displayed on small resolutions.  [integer]
 // @param $mediumColumns {Number} The number of columns to be displayed on medium resolutions.  [integer]
 // @param $largeColumns {Number} The number of columns to be displayed on large resolutions.  [integer]
-// @param $flush {String} Whether or not the columns should be flush on the outside edge of their container.  This also sets the mult-grid container to act as a nested row.  Default value: false.
+// @param $flush {Boolean} Whether or not the columns should be flush on the outside edge of their container.  This also sets the mult-grid container to act as a nested row.  Default value: false.
 // @param $padding {String} A padding override to be set on all columns in the multi-grid.  Default value: $columnPadding. [px|em]
 // @param $smallBreak {String} The breakpoint at which to apply the number of columns defined by $smallColumns.  Default value: breakpointSmall.
 // @param $mediumBreak {String} The breakpoint at which to apply the number of columns defined by $mediumColumns.  Default value: breakpointMedium.
 // @param $largeBreak {String} The breakpoint at which to apply the number of columns defined by $largeColumns.  Default value: breakpointLarge.
 // @usage
 // multi-grid("> li", 1, 2, 3)
-// multi-grid("> li", 1, 2, 3, flush, 10px)
-@mixin multi-grid($selector, $smallColumns, $mediumColumns, $largeColumns, $flush: false, $padding: $columnPadding, $smallBreak: breakpointSmall, $mediumBreak: breakpointMedium, $largeBreak: breakpointLarge) {
+// multi-grid("> li", 1, 2, 3, (flush: true, padding: 10px))
+@mixin multi-grid($selector, $smallColumns, $mediumColumns, $largeColumns, $options: ()) {
+	$options: map-merge((
+		flush: false,
+		padding: $columnPadding,
+		smallBreak: breakpointSmall,
+		mediumBreak: breakpointMedium,
+		largeBreak: breakpointLarge
+	), $options);
+
+	$flush: map-get($options, flush);
+	$padding: map-get($options, padding);
+	$smallBreak: map-get($options, smallBreak);
+	$mediumBreak: map-get($options, mediumBreak);
+	$largeBreak: map-get($options, largeBreak);
+
 	// this is the container
-	@if $flush == flush {
+	@if $flush == true {
 		@include row((nested: nested));
-		margin: 0  (-1 * $padding);
+		margin: 0 (-1 * $padding);
 	}
 	@else {
 		@include row();

--- a/Assets/src/css/mixins/grid/_multi-grid.scss
+++ b/Assets/src/css/mixins/grid/_multi-grid.scss
@@ -17,7 +17,7 @@
 @mixin multi-grid($selector, $smallColumns, $mediumColumns, $largeColumns, $flush: false, $padding: $columnPadding, $smallBreak: breakpointSmall, $mediumBreak: breakpointMedium, $largeBreak: breakpointLarge) {
 	// this is the container
 	@if $flush == flush {
-		@include row(nested);
+		@include row((nested: nested));
 		margin: 0  (-1 * $padding);
 	}
 	@else {

--- a/Assets/src/css/mixins/grid/_semantic-grid.scss
+++ b/Assets/src/css/mixins/grid/_semantic-grid.scss
@@ -148,7 +148,7 @@
 		margin-left: 0;
 
 		@include media(breakpointMedium) {
-			margin-left: push_x($columns, $firstChild);
+			margin-left: push_x($columns, (firstChild: $firstChild));
 		}
 	}
 }

--- a/Assets/src/css/mixins/grid/_semantic-grid.scss
+++ b/Assets/src/css/mixins/grid/_semantic-grid.scss
@@ -10,7 +10,7 @@
 
 // @function row
 // Creates a semantic-grid row.
-// @param $nested {String} Whether or not the row will be nested within other rows.  Default value: false.
+// @param $nested {Boolean} Whether or not the row will be nested within other rows.  Default value: false.
 // @param $padding {Number} A padding override to be set on the row.  Default value: $columnPadding. [px|em]
 // @param $maxWidth {Number} A max-width override to be set on the row.  Default value: $rowMaxWidth. [px|percentage]
 // @usage
@@ -34,7 +34,7 @@
 	min-width: 0;
 	width: auto;
 
-	@if $nested == nested {
+	@if $nested == true {
 		margin-top: $columnPadding;
 		padding: 0;
 
@@ -47,7 +47,7 @@
 	}
 
 	@include media(breakpointMedium) {
-		@if $nested == nested {
+		@if $nested == true {
 			max-width: none;
 			min-width: 0px;
 			padding: 0;
@@ -68,7 +68,7 @@
 // @param $columns {Number} The number of columns you wish your element's width to occupy. [integer]
 // @param $shifted {Boolean} Whether you will be pushing or pulling the columns.  Default value: false.
 // @param $padding {Number} A padding override to be set on the row.  Default value: $columnPadding.  [px|em]
-// @param $nested {String} Whether or not the columns will be contained within a nested row.  Default value: false.
+// @param $nested {Boolean} Whether or not the columns will be contained within a nested row.  Default value: false.
 // @param $alignmnet {String} Whether or not the columns will be centered within a row.  Default value: false.
 // @usage
 // column(8)
@@ -105,7 +105,7 @@
 		@extend %column-config;
 		padding: $padding;
 
-		@if $nested == nested {
+		@if $nested == true {
 			margin-top: $columnPadding;
 
 			&:first-child {

--- a/Assets/src/css/mixins/grid/_semantic-grid.scss
+++ b/Assets/src/css/mixins/grid/_semantic-grid.scss
@@ -133,9 +133,17 @@
 // @function push
 // Pushes a semantic-grid set of columns by the number of columns specified.
 // @param $columns {Number} The number of columns to push the set of columns.  [integer]
+// @param $firstChild {Boolean} Whether or not the element being pushed is the first-child in its container.  Default value: false.
 // @usage
 // push(4)
-@mixin push($columns, $firstChild: false) {
+// push(4, (firstChild: true))
+@mixin push($columns, $options: ()) {
+	$options: map-merge((
+		firstChild: false
+	), $options);
+
+	$firstChild: map-get($options, firstChild);
+
 	@if ($columns > 0) {
 		margin-left: 0;
 
@@ -160,7 +168,7 @@
 
 		@include media(breakpointMedium) {
 			margin-left: pull_x($columns, $width);
-			
+
 			&:first-child {
 				margin-left: 0;
 			}

--- a/Assets/src/css/mixins/grid/_semantic-grid.scss
+++ b/Assets/src/css/mixins/grid/_semantic-grid.scss
@@ -15,11 +15,21 @@
 // @param $maxWidth {Number} A max-width override to be set on the row.  Default value: $rowMaxWidth. [px|percentage]
 // @usage
 // row()
-// row(nested)
-// row(false, 0 50px 0 0)
-@mixin row($nested: false, $padding: $columnPadding, $maxWidth: $rowMaxWidth) {
+// row((nested: nested))
+// row((padding: 0 50px 0 0))
+@mixin row($options: ()) {
+	$options: map-merge((
+		nested: false,
+		padding: $columnPadding,
+		maxWidth: $rowMaxWidth
+	), $options);
+
+	$nested: map-get($options, nested);
+	$padding: map-get($options, padding);
+	$maxWidth: map-get($options, maxWidth);
+
 	@extend %clearfix;
-	margin-left: 0; 
+	margin-left: 0;
 	margin-right: 0;
 	min-width: 0;
 	width: auto;

--- a/Assets/src/css/mixins/grid/_semantic-grid.scss
+++ b/Assets/src/css/mixins/grid/_semantic-grid.scss
@@ -62,7 +62,7 @@
 // @param $alignmnet {String} Whether or not the columns will be centered within a row.  Default value: false.
 // @usage
 // column(8)
-// column(8, 10px)
+// column(8, (padding: 10px))
 @mixin column($columns, $options: ()) {
 	$options: map-merge((
 		shifted: false,

--- a/Assets/src/css/mixins/grid/_semantic-grid.scss
+++ b/Assets/src/css/mixins/grid/_semantic-grid.scss
@@ -56,14 +56,26 @@
 // @function column
 // Creates a semantic-grid set of columns based on the base grid system settings.  On low resolutions, the columns will stack and will break at breakpointMedium to the number of columns specified.
 // @param $columns {Number} The number of columns you wish your element's width to occupy. [integer]
-// @param $shifted {Boolean} Whether you will be pushing or pulling the columns.
+// @param $shifted {Boolean} Whether you will be pushing or pulling the columns.  Default value: false.
 // @param $padding {Number} A padding override to be set on the row.  Default value: $columnPadding.  [px|em]
 // @param $nested {String} Whether or not the columns will be contained within a nested row.  Default value: false.
 // @param $alignmnet {String} Whether or not the columns will be centered within a row.  Default value: false.
 // @usage
 // column(8)
 // column(8, 10px)
-@mixin column($columns, $shifted: false, $padding: $columnPadding, $nested: false, $alignment: false) {
+@mixin column($columns, $options: ()) {
+	$options: map-merge((
+		shifted: false,
+		padding: $columnPadding,
+		nested: false,
+		alignment: false
+	), $options);
+
+	$shifted: map-get($options, shifted);
+	$padding: map-get($options, padding);
+	$nested: map-get($options, nested);
+	$alignment: map-get($options, alignment);
+
 	@if $alignment == centered {
 		@extend %column-config;
 		padding: $padding;

--- a/Assets/src/css/modules/_badges.scss
+++ b/Assets/src/css/modules/_badges.scss
@@ -13,8 +13,8 @@ $badgeBorderRadius: 8px;
 	cursor: default;
 	display: inline-block;
 	@include font-size(12);
-	margin-right: em(6, 12);
-	padding: em(6, 12);
+	margin-right: em(6, (context: 12));
+	padding: em(6, (context: 12));
 }
 
 .badge-primary {

--- a/Assets/src/css/modules/_buttons.scss
+++ b/Assets/src/css/modules/_buttons.scss
@@ -11,8 +11,8 @@
 	color: white;
 	display: inline-block;
 	@include font-size(18);
-	margin-right: em(5, 18);
-	padding: em(6 12, 18);
+	margin-right: em(5, (context: 18));
+	padding: em(6 12, (context: 18));
 	text-align: center;
 	text-decoration: none;
 
@@ -29,7 +29,7 @@
 
 	&.btn-small {
 		@include font-size(14);
-		padding: em(6 12, 14);
+		padding: em(6 12, (context: 14));
 	}
 
 	// sibling buttons may be too wide on low resolutions and wrap to multiple lines

--- a/Assets/src/css/modules/_fancybox.scss
+++ b/Assets/src/css/modules/_fancybox.scss
@@ -80,7 +80,7 @@
 }
 
 #fancybox-loading, .fancybox-close, .fancybox-prev span, .fancybox-next span {
-	@include retina-image('fancybox-sprite.png', 44px 152px);
+	@include retina-image('fancybox-sprite.png', (backgroundSize: 44px 152px));
 }
 
 #fancybox-loading {
@@ -96,7 +96,7 @@
 }
 
 #fancybox-loading div {
-	@include retina-image('fancybox-loading.gif', 24px 24px);
+	@include retina-image('fancybox-loading.gif', (backgroundSize: 24px 24px));
 	background-position: center center;
 	background-repeat: no-repeat;
 	height: 44px;

--- a/Assets/src/css/modules/_forms.scss
+++ b/Assets/src/css/modules/_forms.scss
@@ -92,7 +92,7 @@ fieldset {
 $decoratorSelectBorderSize: 1px;
 
 .decorator-select {
-	@include gradient($colorGreyLight, $colorGreyMedium);
+	@include gradient((from: $colorGreyLight, to: $colorGreyMedium));
 	background-size: 100%;
 	border: $decoratorSelectBorderSize solid $colorGreyMedium;
 	border-radius: $formElementBorderRadius;

--- a/Assets/src/css/modules/_forms.scss
+++ b/Assets/src/css/modules/_forms.scss
@@ -131,7 +131,7 @@ $decoratorSelectBorderSize: 1px;
 
 // multiple selects
 .decorator-select-multiple {
-	@include gradient($colorGreyLight, $colorGreyMedium);
+	@include gradient((from: $colorGreyLight, to: $colorGreyMedium));
 	border: $decoratorSelectBorderSize solid $colorGreyMedium;
 	border-radius: $formElementBorderRadius;
 	display: inline-block;

--- a/Assets/src/css/modules/_forms.scss
+++ b/Assets/src/css/modules/_forms.scss
@@ -92,7 +92,7 @@ fieldset {
 $decoratorSelectBorderSize: 1px;
 
 .decorator-select {
-	@include gradient((from: $colorGreyLight, to: $colorGreyMedium));
+	@include gradient($colorGreyLight, $colorGreyMedium);
 	background-size: 100%;
 	border: $decoratorSelectBorderSize solid $colorGreyMedium;
 	border-radius: $formElementBorderRadius;
@@ -131,7 +131,7 @@ $decoratorSelectBorderSize: 1px;
 
 // multiple selects
 .decorator-select-multiple {
-	@include gradient((from: $colorGreyLight, to: $colorGreyMedium));
+	@include gradient($colorGreyLight, $colorGreyMedium);
 	border: $decoratorSelectBorderSize solid $colorGreyMedium;
 	border-radius: $formElementBorderRadius;
 	display: inline-block;

--- a/Assets/src/css/modules/_navigation.scss
+++ b/Assets/src/css/modules/_navigation.scss
@@ -9,7 +9,7 @@
 	display: block;
 	@include font-size(24);
 	margin: (-$columnPadding) (-$columnPadding) 0 (-$columnPadding);	// need parentheses around -$columnPadding to compile correctly
-	padding: em(12, 24);
+	padding: em(12, (context: 24));
 
 	@include media(breakpointMedium) {
 		display: none;

--- a/Assets/src/css/modules/_navigation.scss
+++ b/Assets/src/css/modules/_navigation.scss
@@ -17,12 +17,12 @@
 }
 
 .brand {
-	@include column(7, true);
+	@include column(7, (shifted: true));
 	@include pull(5, 7);
 }
 
 #nav {
-	@include column(5, true);
+	@include column(5, (shifted: true));
 	@include push(7);
 }
 

--- a/Assets/src/css/modules/_navigation.scss
+++ b/Assets/src/css/modules/_navigation.scss
@@ -32,7 +32,7 @@
 	margin: 0 (-$columnPadding);
 	max-height: 0;
 	overflow: hidden;
-	@include transition(max-height, 0.5s, ease-in-out);
+	@include transition((property: max-height, duration: 0.5s, easing: ease-in-out));
 
 	&.expanded {
 		max-height: rem(500);

--- a/Assets/src/css/modules/_responsive-tabs.scss
+++ b/Assets/src/css/modules/_responsive-tabs.scss
@@ -37,7 +37,7 @@ $tabPanelTextColor: black;
 	color: $tabTextColor;
 	cursor: pointer;
 	display: block;
-	padding: em(9, 18);
+	padding: em(9, (context: 18));
 	position: relative;
 
 	&:after {
@@ -179,7 +179,7 @@ $tabPanelTextColor: black;
 	border-top-right-radius: $tabBorderRadius;
 	color: $tabTextColor;
 	cursor: pointer;
-	padding: em(10 20, 19);
+	padding: em(10 20, (context: 19));
 
 	&:hover {
 		background: $tabHoverBackgroundColor;
@@ -218,7 +218,7 @@ $tabPanelTextColor: black;
 		@include media(breakpointMedium) {
 			.responsive-tabs-horizontal & {
 				border-bottom: none;
-				padding-top: em(11, 19);
+				padding-top: em(11, (context: 19));
 				position: relative;
 				top: 1px;
 			}

--- a/Assets/src/css/modules/_utility.scss
+++ b/Assets/src/css/modules/_utility.scss
@@ -56,11 +56,11 @@ $quickColumnGapWidth: 0.3;
 
 	// starting on the second item
 	&.nth-child-np2 {
-		margin-top: columns($quickColumnGapWidth, false);
+		margin-top: columns($quickColumnGapWidth, (includeGutterWidth: false));
 	}
 
 	@include media(breakpointLarge) {
-		margin-left: columns($quickColumnGapWidth, false);
+		margin-left: columns($quickColumnGapWidth, (includeGutterWidth: false));
 		margin-right: -0.25em;	// eliminate whitespace created by inline-block
 
 		// starting on the second item
@@ -73,7 +73,7 @@ $quickColumnGapWidth: 0.3;
 .two-up,
 .four-up {
 	@include media(breakpointLarge) {
-		width: columns( ($columns - $quickColumnGapWidth) / 2, false);
+		width: columns( ($columns - $quickColumnGapWidth) / 2, (includeGutterWidth: false));
 
 		// first of each row
 		&.nth-child-2np1 {
@@ -82,14 +82,14 @@ $quickColumnGapWidth: 0.3;
 
 		// starting on the second row
 		&.nth-child-np3 {
-			margin-top: columns($quickColumnGapWidth, false);
+			margin-top: columns($quickColumnGapWidth, (includeGutterWidth: false));
 		}
 	}
 }
 
 .three-up {
 	@include media(breakpointLarge) {
-		width: columns( ($columns - 2 * $quickColumnGapWidth) / 3, false );
+		width: columns( ($columns - 2 * $quickColumnGapWidth) / 3, (includeGutterWidth: false));
 
 		// first of each row
 		&.nth-child-3np1 {
@@ -98,18 +98,18 @@ $quickColumnGapWidth: 0.3;
 
 		// starting on the second row
 		&.nth-child-np4 {
-			margin-top: columns($quickColumnGapWidth, false);
+			margin-top: columns($quickColumnGapWidth, (includeGutterWidth: false));
 		}
 	}
 }
 
 .four-up {
 	@include media(breakpointExtraLarge) {
-		width: columns( ($columns - 3 * $quickColumnGapWidth) / 4, false );
+		width: columns( ($columns - 3 * $quickColumnGapWidth) / 4, (includeGutterWidth: false));
 
 		// first of each row (override from breakpointLarge)
 		&.nth-child-2np1 {
-			margin-left: columns($quickColumnGapWidth, false);
+			margin-left: columns($quickColumnGapWidth, (includeGutterWidth: false));
 		}
 		// first of each row
 		&.nth-child-4np1 {
@@ -122,7 +122,7 @@ $quickColumnGapWidth: 0.3;
 		}
 		// starting on the second row
 		&.nth-child-np5 {
-			margin-top: columns($quickColumnGapWidth, false);
+			margin-top: columns($quickColumnGapWidth, (includeGutterWidth: false));
 		}
 	}
 }

--- a/Assets/src/css/modules/_video.scss
+++ b/Assets/src/css/modules/_video.scss
@@ -2,6 +2,8 @@
 
 // @function video
 // Responsive video for maintaining aspect ratio on all resolutions.
-body .video {
-	@include aspect-ratio();
+
+// you will need to change this class if you add the video test to Modernizr
+.video {
+	@include aspect-ratio(16, 9);
 }

--- a/Assets/src/package.json
+++ b/Assets/src/package.json
@@ -1,6 +1,6 @@
 {
-  	"name": "Phoenix",
-  	"version": "1.0.0",
+	"name": "Phoenix",
+	"version": "1.0.2",
 	"description": "Build framework for Phoenix frontend framework",
 	"repository": "https://github.com/isitedesign/Phoenix",
 	"devDependencies": {
@@ -13,7 +13,7 @@
 		"del": "~1.1.1",
 
 		"gulp": "~3.8.10",
-		
+
 		"gulp-filter": "~2.0.0",
 		"gulp-ignore": "~1.2.1",
 		"gulp-if": "~1.2.5",
@@ -27,12 +27,12 @@
 		"gulp-combine-media-queries": "~0.2.0",
 		"gulp-autoprefixer": "~2.0.0",
 		"gulp-minify-css": "~0.3.11",
-		
+
 		"browserify": "~8.0.3",
 		"gulp-uglify": "~1.0.2",
 
 		"gulp-imagemin": "~2.1.0",
 
 		"jquery": "~1.11.1"
-  	}
+	}
 }

--- a/documentation/index.php
+++ b/documentation/index.php
@@ -145,6 +145,7 @@
 						<div class="responsive-tabs-content">
 							<div class="doc-callout">
 								<p>The functions folder contains utility functions that allow for consistent, reusable calculations across the project.</p>
+								<p><strong>NOTE:</strong> if a parameter has a default value, it should be included in a map as the last parameter.  The key name should match that of the parameter name listed below.</p>
 							</div>
 							<div class="doc-callout divider" ng-repeat="function in objects.functions">
 								<h2>
@@ -189,6 +190,7 @@
 						<div class="responsive-tabs-content">
 							<div class="doc-callout">
 								<p>The mixins folder contains utility mixins that allow for consistent, reusable output across the project.  Mixins can be particularly useful for writing patterns that require vendor prefixes or fallbacks for older browsers.</p>
+								<p><strong>NOTE:</strong> if a parameter has a default value, it should be included in a map as the last parameter.  The key name should match that of the parameter name listed below.</p>
 							</div>
 							<div class="doc-callout divider" ng-repeat="mixin in objects.mixins">
 								<h2>


### PR DESCRIPTION
This changes our functions and mixins to allow for optional parameters to be passed into the function or mixin as part of an optional map.  Doing so will provide a couple advantages:

- Fewer parameters in calls when you want to change one optional parameter (see a [column mixin](https://github.com/isitedesign/Phoenix/commit/9f095c0184e4c0732a4fb5617f5ccc2e5a0a8038#diff-d553f561220a9f3abfba46dbcc910769L44) example)
- Clearer syntax to know what optional parameters are being passed

That said, sometimes the syntax is more verbose than before in a way that may not be 100% desirable, such as the syntax for [em functions](https://github.com/isitedesign/Phoenix/commit/674e161bed36fe5c537a861bc521dbff29ec46ea#diff-ada6102e154c12e8d64b0e0713c63abaR59), [gradients](https://github.com/isitedesign/Phoenix/commit/9bb754327320fe1f5d64493c17de0ee5a2f3cc35#diff-b48b0756b0ba7e7dbecfc8bf920c91baR95), or [aspect ratio](https://github.com/isitedesign/Phoenix/commit/9396ace29bb39f4b0d59d137ee658edb0aa3e535#diff-d553f561220a9f3abfba46dbcc910769R116).  Some additional ideas to consider/discuss:

- Should we make the parameters for mixins such as gradient and aspect-ratio have only required parameters?  I did this with the [font-size mixin](https://github.com/isitedesign/Phoenix/commit/3ab1e416db0e3323f2e0decc81037307e29f69fe) for simplicity and I think it might work well with others such as these two.  NOTE:  Since we have maps support now, I've opened #107 for consideration of changing how our gradient mixin works anyway.
- Documentation is sub-optimal due to limitations of sassdoc.  Short-term:  creative alternatives to explain the methodology behind optional parameters would be most welcome.  Long-term:  alternatives to sassdoc that give us more granular control over documentation would be great.