### PR TITLE
Adds CSS source maps to debugging builds

### DIFF
--- a/Assets/src/build/drivers/css.js
+++ b/Assets/src/build/drivers/css.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var sass = require('gulp-sass');
+var sourcemaps = require('gulp-sourcemaps');
 var prefix = require('gulp-autoprefixer');
 var cssmin = require('gulp-minify-css');
 var cmq = require('gulp-combine-media-queries');
@@ -10,9 +11,11 @@ var gulpif = require('gulp-if');
 var CssDriver = {
 	build: function(pipeline, debug) {
 		return pipeline
+			.pipe(gulpif(debug, sourcemaps.init()))
 			.pipe(sass())
-			.pipe(prefix('last 2 versions', 'IE >= 8', 'Android >= 4'))
-			.pipe(cmq())
+			.pipe(gulpif(debug, sourcemaps.write('./')))
+			.pipe(gulpif(!debug, prefix('last 2 versions', 'IE >= 8', 'Android >= 4')))
+			.pipe(gulpif(!debug, cmq()))
 			.pipe(gulpif(!debug, cssmin({
 				noAdvanced: true
 			})));

--- a/Assets/src/build/drivers/css.js
+++ b/Assets/src/build/drivers/css.js
@@ -14,7 +14,9 @@ var CssDriver = {
 			.pipe(gulpif(debug, sourcemaps.init()))
 			.pipe(sass())
 			.pipe(gulpif(debug, sourcemaps.write('./')))
-			.pipe(gulpif(!debug, prefix('last 2 versions', 'IE >= 8', 'Android >= 4')))
+			.pipe(gulpif(!debug, prefix({
+				browsers: ['last 2 versions', 'IE >= 8', 'Android >= 4']
+			})))
 			.pipe(gulpif(!debug, cmq()))
 			.pipe(gulpif(!debug, cssmin({
 				noAdvanced: true

--- a/Assets/src/package.json
+++ b/Assets/src/package.json
@@ -26,7 +26,7 @@
 		"gulp-sass": "1.2.4",
 		"gulp-sourcemaps": "~1.3.0",
 		"gulp-combine-media-queries": "~0.2.0",
-		"gulp-autoprefixer": "~2.0.0",
+		"gulp-autoprefixer": "~2.1.0",
 		"gulp-minify-css": "~0.3.11",
 
 		"browserify": "~8.0.3",

--- a/Assets/src/package.json
+++ b/Assets/src/package.json
@@ -24,6 +24,7 @@
 		"gulp-livereload": "~3.0.2",
 
 		"gulp-sass": "1.2.4",
+		"gulp-sourcemaps": "~1.3.0",
 		"gulp-combine-media-queries": "~0.2.0",
 		"gulp-autoprefixer": "~2.0.0",
 		"gulp-minify-css": "~0.3.11",


### PR DESCRIPTION
This change to the build process will add CSS source maps when debugging is enabled.  Due to restrictions of the [gulp-sourcemaps](https://www.npmjs.com/package/gulp-sourcemaps) package, there is one minor concern:  both autoprefixer and combine media queries had to be moved to only execute on non-debugging builds (e.g. production).  This is due to restrictions on which [plugins support Gulp source maps](https://github.com/floridoo/gulp-sourcemaps/wiki/Plugins-with-gulp-sourcemaps-support).  You'll see autoprefixer is on that list, though I was not able to get it to work properly.  Let me know if you get this to work properly.

This restriction would mean that builds, particularly non-debugging builds, will need to be tested thoroughly before a release and prefix-related issues could arise with debugging builds.  Despite this, I believe the pros of having access to CSS source maps far outweigh these cons.

If you'd like to test this branch, you'll probably want to take a look at how to utilize the source maps in your browser of choice:

- Chrome - [official Google doc](https://developer.chrome.com/devtools/docs/css-preprocessors) or [Sass Bites video podcast](https://www.youtube.com/watch?v=VKvb-D_QdYM#t=9m45s), a quick run-through by Micah Godbolt, the organizer of PDX Sass
- [Firefox](https://hacks.mozilla.org/2014/02/live-editing-sass-and-less-in-the-firefox-developer-tools/)
- [Internet Explorer](http://msdn.microsoft.com/en-us/library/ie/bg182326(v=vs.85).aspx) (if you're so inclined; I haven't tested this)