### PR TITLE
Color maps

### DIFF
--- a/Assets/src/css/base/defaults/_forms.scss
+++ b/Assets/src/css/base/defaults/_forms.scss
@@ -54,12 +54,12 @@ fieldset {
 	input[type="email"],
 	input[type="tel"],
 	textarea {
-		background-color: $colorGreyLight;
-		border: 1px solid $colorGreyMedium;
+		background-color: color(greyLight);
+		border: 1px solid color(greyMedium);
 		border-radius: $formElementBorderRadius;
 		max-width: 100%;
 		padding: em(8);
-		@include placeholder-color($colorGreyDark);
+		@include placeholder-color(color(greyDark));
 		width: 100%;
 	}
 

--- a/Assets/src/css/base/defaults/_lists.scss
+++ b/Assets/src/css/base/defaults/_lists.scss
@@ -4,7 +4,7 @@ ul {
 	padding-left: em($listBulletSize);
 
 	li:before {
-		color: $colorPrimary;
+		color: color(primary);
 		content: "\2022";
 		display: inline-block;
 		float: left;

--- a/Assets/src/css/base/defaults/_tables.scss
+++ b/Assets/src/css/base/defaults/_tables.scss
@@ -10,7 +10,7 @@ table {
 	}
 
 	th {
-		background-color: $colorPrimary;
+		background-color: color(primary);
 		color: white;
 		font-weight: normal;
 		vertical-align: middle;
@@ -29,7 +29,7 @@ table {
 	// zebra striping code needs to repeat because IE < 8 will ignore the code if an nth-child selector is in it
 	tr:nth-child(2n) {
 		> td {
-			background-color: $colorGreyLight;
+			background-color: color(greyLight);
 
 			&.empty,
 			&.plain {
@@ -39,7 +39,7 @@ table {
 	}
 	tr.even {
 		> td {
-			background-color: $colorGreyLight;
+			background-color: color(greyLight);
 
 			&.empty,
 			&.plain {

--- a/Assets/src/css/base/defaults/_typography.scss
+++ b/Assets/src/css/base/defaults/_typography.scss
@@ -5,7 +5,7 @@ a {
 	&:hover,
 	&:active,
 	&:focus {
-		color: $colorGreyMedium;
+		color: color(greyMedium);
 	}
 
 	@include media(print) {

--- a/Assets/src/css/documentation.scss
+++ b/Assets/src/css/documentation.scss
@@ -99,7 +99,7 @@
 }
 
 .doc-footer {
-	background-color: $colorPrimary;
+	background-color: color(primary);
 	color: white;
 	max-width: none;
 
@@ -109,7 +109,7 @@
 		&:hover,
 		&:active,
 		&:focus {
-			color: $colorGreyMedium;
+			color: color(greyMedium);
 		}
 	}
 }

--- a/Assets/src/css/functions/_all.scss
+++ b/Assets/src/css/functions/_all.scss
@@ -1,3 +1,4 @@
+@import "color";
 @import "divide-columns";
 @import "em";
 @import "grid-calc";

--- a/Assets/src/css/functions/_color.scss
+++ b/Assets/src/css/functions/_color.scss
@@ -8,10 +8,11 @@
 // =color(primary) will return the result of map-get( $colors, primary )
 
 @function color( $key ) {
-  @if map-has-key( $colors, $key ) {
-    @return map-get( $colors, $key );
-  }
+	@if map-has-key( $colors, $key ) {
+		@return map-get( $colors, $key );
+	}
 
-  @warn "The key value `#{$key}` is not set in $colors.";
-  @return null;
+	@warn "The key value `#{$key}` is not set in $colors.";
+
+	@return null;
 }

--- a/Assets/src/css/functions/_color.scss
+++ b/Assets/src/css/functions/_color.scss
@@ -1,0 +1,17 @@
+// @category functions
+
+// @function color
+// Returns the requested color from the $colors map set in variables/_colors.scss
+// @param $key {String} The requested key from the $colors map.
+// @return {String} The key's value from the $colors map.
+// @usage
+// =color(primary) will return the result of map-get( $colors, primary )
+
+@function color( $key ) {
+  @if map-has-key( $colors, $key ) {
+    @return map-get( $colors, $key );
+  }
+
+  @warn "The key value `#{$key}` is not set in $colors.";
+  @return null;
+}

--- a/Assets/src/css/layout/_content.scss
+++ b/Assets/src/css/layout/_content.scss
@@ -9,7 +9,7 @@
 // standard grid
 .layout-primary,
 .layout-primary-pushed {
-	border: 1px dashed $colorPrimary;
+	border: 1px dashed color(primary);
 }
 
 .layout-primary {
@@ -23,7 +23,7 @@
 
 .layout-secondary,
 .layout-secondary-pulled {
-	background-color: $colorSecondary;
+	background-color: color(secondary);
 }
 
 .layout-secondary {
@@ -37,12 +37,12 @@
 
 .layout-tertiary {
 	@include column(3);
-	background-color: $colorSecondary;
+	background-color: color(secondary);
 }
 
 .layout-centered {
 	@include column(8, (alignment: centered));
-	border: 1px dashed $colorPrimary;
+	border: 1px dashed color(primary);
 }
 
 // complex layout
@@ -62,7 +62,7 @@
 
 .layout-complex-primary {
 	@extend %column-config;
-	border: 1px dashed $colorPrimary;
+	border: 1px dashed color(primary);
 	padding: $columnPadding;
 
 	@include media(breakpointMedium) {
@@ -76,7 +76,7 @@
 
 .layout-complex-nav {
 	@extend %column-config;
-	background-color: $colorSecondary;
+	background-color: color(secondary);
 	padding: $columnPadding;
 
 	@include media(breakpointExtraLarge) {
@@ -86,7 +86,7 @@
 
 .layout-complex-tertiary {
 	@extend %column-config;
-	background-color: $colorSecondary;
+	background-color: color(secondary);
 	padding: $columnPadding;
 
 	@include media(breakpointMedium) {
@@ -126,7 +126,7 @@ aside {
 }
 
 .multi-grid {
-	border: 1px dashed $colorPrimary;
+	border: 1px dashed color(primary);
 
 	> li {
 		&:before {

--- a/Assets/src/css/layout/_footer.scss
+++ b/Assets/src/css/layout/_footer.scss
@@ -3,7 +3,7 @@
 // @function footer
 // The location to define major column layouts and styles for the footer.
 footer {
-	background: $colorGreyLight;
+	background: color(greyLight);
 
 	.column, .columns {
 		margin-top: 0;

--- a/Assets/src/css/layout/_header.scss
+++ b/Assets/src/css/layout/_header.scss
@@ -3,7 +3,7 @@
 // @function header
 // The location to define major column layouts and styles for the header.
 header {
-	background: $colorGreyLight;
+	background: color(greyLight);
 
 	.column, .columns {
 		margin-top: 0;

--- a/Assets/src/css/modules/_badges.scss
+++ b/Assets/src/css/modules/_badges.scss
@@ -19,11 +19,11 @@ $badgeBorderRadius: 8px;
 
 .badge-primary {
 	@extend %badge-config;
-	background-color: $colorPrimary;
+	background-color: color(primary);
 	color: white;
 }
 
 .badge-secondary {
 	@extend %badge-config;
-	background-color: $colorSecondary;
+	background-color: color(secondary);
 }

--- a/Assets/src/css/modules/_buttons.scss
+++ b/Assets/src/css/modules/_buttons.scss
@@ -49,13 +49,13 @@
 button,
 .btn {
 	@extend %button-config;
-	background-color: $colorPrimary;
-	border: 1px solid darken($colorPrimary, 10%);
+	background-color: color(primary);
+	border: 1px solid darken(color(primary), 10%);
 
 	&:hover,
 	&:active,
 	&:focus {
-		background-color: lighten($colorPrimary, 10%);
+		background-color: lighten(color(primary), 10%);
 	}
 
 	@include media(print) {
@@ -65,14 +65,14 @@ button,
 
 .btn-secondary {
 	@extend %button-config;
-	background-color: $colorSecondary;
-	border: 1px solid darken($colorSecondary, 10%);
+	background-color: color(secondary);
+	border: 1px solid darken(color(secondary), 10%);
 	color: black;
 
 	&:hover,
 	&:active,
 	&:focus {
-		background-color: lighten($colorSecondary, 10%);
+		background-color: lighten(color(secondary), 10%);
 	}
 
 	@include media(print) {

--- a/Assets/src/css/modules/_callout.scss
+++ b/Assets/src/css/modules/_callout.scss
@@ -3,7 +3,7 @@
 // @function callout
 // Class used for calling out a specific portion of the page.
 .callout {
-	background: $colorGreyLight;
+	background: color(greyLight);
 	margin-top: em(10);
 	padding: $columnPadding;
 

--- a/Assets/src/css/modules/_forms.scss
+++ b/Assets/src/css/modules/_forms.scss
@@ -40,7 +40,7 @@ fieldset:not(#foo) {
 		}
 		&:active + label,
 		&:focus + label {
-			color: $colorPrimary;
+			color: color(primary);
 		}
 		&:checked + label {
 			&:before {
@@ -57,7 +57,7 @@ fieldset:not(#foo) {
 		}
 		&:active + label,
 		&:focus + label {
-			color: $colorPrimary;
+			color: color(primary);
 		}
 		&:checked + label {
 			&:before {
@@ -92,9 +92,9 @@ fieldset {
 $decoratorSelectBorderSize: 1px;
 
 .decorator-select {
-	@include gradient($colorGreyLight, $colorGreyMedium);
+	@include gradient(color(greyLight), color(greyMedium));
 	background-size: 100%;
-	border: $decoratorSelectBorderSize solid $colorGreyMedium;
+	border: $decoratorSelectBorderSize solid color(greyMedium);
 	border-radius: $formElementBorderRadius;
 	display: inline-block;
 	height: auto;
@@ -131,8 +131,8 @@ $decoratorSelectBorderSize: 1px;
 
 // multiple selects
 .decorator-select-multiple {
-	@include gradient($colorGreyLight, $colorGreyMedium);
-	border: $decoratorSelectBorderSize solid $colorGreyMedium;
+	@include gradient(color(greyLight), color(greyMedium));
+	border: $decoratorSelectBorderSize solid color(greyMedium);
 	border-radius: $formElementBorderRadius;
 	display: inline-block;
 	width: 100%;

--- a/Assets/src/css/modules/_navigation.scss
+++ b/Assets/src/css/modules/_navigation.scss
@@ -45,7 +45,7 @@
 		padding: em(12);
 
 		&:hover {
-			color: $colorGreyMedium;
+			color: color(greyMedium);
 		}
 	}
 

--- a/Assets/src/css/modules/_responsive-tabs.scss
+++ b/Assets/src/css/modules/_responsive-tabs.scss
@@ -8,17 +8,17 @@ $tabBorderColor: black;
 $tabBorderRadius: $formElementBorderRadius;
 
 // tab
-$tabBackgroundColor: $colorPrimary;
+$tabBackgroundColor: color(primary);
 $tabHoverBackgroundColor: lighten($tabBackgroundColor, 10%);
 $tabTextColor: white;
 
 // active tab
-$tabActiveBackgroundColor: $colorGreyLight;
+$tabActiveBackgroundColor: color(greyLight);
 $tabActiveHoverBackgroundColor: lighten($tabActiveBackgroundColor, 10%);
 $tabActiveTextColor: black;
 
 // tab panel
-$tabPanelBackgroundColor: $colorGreyLight;
+$tabPanelBackgroundColor: color(greyLight);
 $tabPanelTextColor: black;
 
 .responsive-tabs-wrapper {

--- a/Assets/src/css/modules/_tooltips.scss
+++ b/Assets/src/css/modules/_tooltips.scss
@@ -8,7 +8,7 @@ $tooltipArrowSize: 5px; // note: keep this under 10px to avoid issues
 $tooltipPadding: 10px;
 
 // colors
-$tooltipBackgroundColor: $colorPrimary;
+$tooltipBackgroundColor: color(primary);
 $tooltipTextColor: white;
 $tooltipShadowColor: black;
 $tooltipShadowBlurRadius: 10px;

--- a/Assets/src/css/modules/_utility.scss
+++ b/Assets/src/css/modules/_utility.scss
@@ -17,7 +17,7 @@
 
 .divider {
 	@extend %divider-config;
-	border-top: 1px solid $colorGreyMedium;
+	border-top: 1px solid color(greyMedium);
 
 	&.row {
 		margin-top: 0;
@@ -26,7 +26,7 @@
 
 .divider-secondary {
 	@extend %divider-config;
-	border-top: 1px dashed $colorGreyMedium;
+	border-top: 1px dashed color(greyMedium);
 }
 
 .img-align-center {

--- a/Assets/src/css/variables/_colors.scss
+++ b/Assets/src/css/variables/_colors.scss
@@ -2,7 +2,7 @@
 
 // @function colors
 // The color palette for the project.
-// @param $colors {List} All colors needed on the project represented as pairs with a color name and its corresponding color value.  [String hex|rgb(a)|hsl(a)]
+// @param $colors {Map} All project color variables represented as pairs with a color name and its corresponding value.  [String hex|rgb(a)|hsl(a)]
 // NOTE: funtions/_color.scss uses the $colors map by default, so if this variable name changes, that function will need to be changed as well.
 
 $colors: (

--- a/Assets/src/css/variables/_colors.scss
+++ b/Assets/src/css/variables/_colors.scss
@@ -2,13 +2,13 @@
 
 // @function colors
 // The color palette for the project.
-// @param $colorPrimary {Color} The color palette's primary color.
-// @param $colorSecondary {Color} The color palette's secondary color.
-// @param $colorGreyLight {Color} A light grey intended for use as a shaded background color.
-// @param $colorGreyMedium {Color} A medium grey intended for use as a border or accent color in conjunction with $colorGreyLight.
-// @param $colorGreyDark {Color} A dark grey intended for us as a text or border color in conjunction with $colorGreyLight or $colorGreyMedium.
-$colorPrimary: #a81e23;
-$colorSecondary: #d1d2d4;
-$colorGreyLight: #eeeeee;
-$colorGreyMedium: #cccccc;
-$colorGreyDark: #6d6d6d;
+// @param $colors {List} All colors needed on the project represented as pairs with a color name and its corresponding color value.  [String hex|rgb(a)|hsl(a)]
+// NOTE: funtions/_color.scss uses the $colors map by default, so if this variable name changes, that function will need to be changed as well.
+
+$colors: (
+	primary: #a81e23,
+	secondary: #d1d2d4,
+	greyLight: #eeeeee,
+	greyMedium: #cccccc,
+	greyDark: #6d6d6d
+);


### PR DESCRIPTION
As we now have Sass maps at our disposal, we can convert our color variables to a map as well. I did this on a recent one-page project and found it faster and more intuitive/easier to reach for than the variables alone when used in combination with a `color()` function (even though it plays out to be one character longer than the variable alone). That last parenthetical is one reason I can see for this being argued against. Anyway:

*  converts all color variables to a new `$colors` list
*  updates documentation in `variables/_color.scss`
*  adds a new `color()` function that acts as a shorthand for `map-get($colors, color)`
*  updates all usage of color variables in default codebase to use `color()`

(I already had the code worked out for that one-page project, so opening this for discussion with code attached, should it be a desired update.)