### PR TITLE
Icon Map

### DIFF
--- a/Assets/src/css/base/defaults/_icons.scss
+++ b/Assets/src/css/base/defaults/_icons.scss
@@ -23,11 +23,4 @@
 [class^="icon-"], [class*=" icon-"] {
 	@extend %icon-config;
 }
-
-.icon-arrow-down:before {
-	content: $iconArrowDown;
-}
-
-.icon-arrow-up:before {
-	content: $iconArrowUp;
 }

--- a/Assets/src/css/base/defaults/_icons.scss
+++ b/Assets/src/css/base/defaults/_icons.scss
@@ -1,10 +1,3 @@
-$iconArrowDown: "\e600";
-$iconArrowUp: "\e601";
-$iconCheckboxChecked: "\e602";
-$iconCheckboxUnchecked: "\e603";
-$iconRadioChecked: "\e604";
-$iconRadioUnchecked: "\e605";
-$iconFontFamily: 'icomoon';
 
 @mixin icon() {
 	font-family: $iconFontFamily;

--- a/Assets/src/css/base/defaults/_icons.scss
+++ b/Assets/src/css/base/defaults/_icons.scss
@@ -1,5 +1,10 @@
-
-@mixin icon() {
+// Base Icon Styles Mixin
+// using a mixin rather than placeholder because we need to separate
+// modern browser from older browsers in @extend chain so as not to break
+// older browsers when used in form elememts (see modules/forms)
+// once IE8 support is dropped, this should become a placeholder
+// and %icon-config/%icon-config-modern-browsers can be removed
+@mixin icon-config() {
 	font-family: $iconFontFamily;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
@@ -12,15 +17,14 @@
 }
 
 %icon-config {
-	@include icon();
+	@include icon-config();
 }
 
 // this version is for IE9 and up; it's used on custom radio buttons and checkboxes and must be separate from %icon-config
 %icon-config-modern-browsers {
-	@include icon();
+	@include icon-config();
 }
 
 [class^="icon-"], [class*=" icon-"] {
 	@extend %icon-config;
-}
 }

--- a/Assets/src/css/functions/_all.scss
+++ b/Assets/src/css/functions/_all.scss
@@ -1,6 +1,7 @@
 @import "divide-columns";
 @import "em";
 @import "grid-calc";
+@import "icon";
 @import "image";
 @import "parse-int";
 @import "rem";

--- a/Assets/src/css/functions/_icon.scss
+++ b/Assets/src/css/functions/_icon.scss
@@ -1,0 +1,25 @@
+// @function Icon
+// retrieves the passed icon from a specified icon map variable
+// defaults to using the $icons map
+// makes a recursive check to allow for self-referencing map keys
+
+@function icon($icon, $iconMap: $icons) {
+	// check $icon exists in $iconMap
+	@if map-has-key($iconMap, $icon) {
+		$icon: map-get($icons, $icon);
+
+		// recursive call to check for self-referencing icon keys
+		// i.e.: $icons: ( check: "\e007", tick: check )
+		// @include icon(tick) will return check => "\e007"
+		@if map-has-key($icons, $icon) {
+			$icon: icon($icon);
+		}
+	}
+	@else {
+		@warn "The icon you called -- #{$icon} -- is not in the #{$iconMap} icon map.";
+
+		@return null;
+	}
+
+	@return $icon;
+}

--- a/Assets/src/css/mixins/_all.scss
+++ b/Assets/src/css/mixins/_all.scss
@@ -3,7 +3,6 @@
 @import "gradients";
 @import "high-dpi";
 @import "icon";
-@import "icon-config";
 @import "media";
 @import "opacity";
 @import "placeholder-color";

--- a/Assets/src/css/mixins/_all.scss
+++ b/Assets/src/css/mixins/_all.scss
@@ -2,6 +2,8 @@
 @import "font-size";
 @import "gradients";
 @import "high-dpi";
+@import "icon";
+@import "icon-config";
 @import "media";
 @import "opacity";
 @import "placeholder-color";

--- a/Assets/src/css/mixins/_icon.scss
+++ b/Assets/src/css/mixins/_icon.scss
@@ -1,0 +1,46 @@
+// Icon Mixin
+// retrieves the passed icon from an icon map
+// @uses icon() function to assign passed icon to :before content
+// usage:
+/*
+	EXAMPLE 1
+	==========
+	.icon-arrow-up {
+		@include icon(arrow-up);
+	}
+
+	RETURNS =>
+
+	.icon-arrow-up:before {
+		content: "\e601";
+	}
+
+	EXAMPLE 2
+	==========
+	.icon-arrow-up {
+		@include icon(arrow-up) {
+			font-size: rem(24);
+			color: color(colorPrimary);
+			margin-right: rem(4);
+		}
+	}
+
+	RETURNS =>
+
+	.icon-arrow-up:before {
+		color: #a81e23;
+		content: "\e601";
+		font-size: 24px;
+		font-size: 1.5rem;
+		margin-right: 4px;
+		margin-right: .25rem;
+	}
+
+*/
+
+@mixin icon($name, $pseudo: before, $iconMap: $icons) {
+	&:#{$pseudo} {
+		content: icon($name, $iconMap);
+		@content; // allows additional CSS declarations to be passed
+	}
+}

--- a/Assets/src/css/modules/_all.scss
+++ b/Assets/src/css/modules/_all.scss
@@ -3,6 +3,7 @@
 @import "callout";
 @import "fancybox";
 @import "forms";
+@import "icons";
 @import "lists";
 @import "navigation";
 @import "responsive-tabs";

--- a/Assets/src/css/modules/_forms.scss
+++ b/Assets/src/css/modules/_forms.scss
@@ -34,35 +34,27 @@ fieldset:not(#foo) {
 
 	input[type="radio"] {
 		& + label {
-			&:before {
-				content: $iconRadioUnchecked;
-			}
+			@include icon(radio-unchecked);
 		}
 		&:active + label,
 		&:focus + label {
 			color: $colorPrimary;
 		}
 		&:checked + label {
-			&:before {
-				content: $iconRadioChecked;
-			}
+			@include icon(radio-checked);
 		}
 	}
 
 	input[type="checkbox"] {
 		& + label {
-			&:before {
-				content: $iconCheckboxUnchecked;
-			}
+			@include icon(checkbox-unchecked);
 		}
 		&:active + label,
 		&:focus + label {
 			color: $colorPrimary;
 		}
 		&:checked + label {
-			&:before {
-				content: $iconCheckboxChecked;
-			}
+			@include icon(checkbox-checked);
 		}
 	}
 }

--- a/Assets/src/css/modules/_icons.scss
+++ b/Assets/src/css/modules/_icons.scss
@@ -1,0 +1,13 @@
+// @category modules
+
+// @function icons
+// Specific icon font declarations
+// Defaults are set in base/defaults/icons
+
+.icon-arrow-down {
+	@include icon(arrow-down);
+}
+
+.icon-arrow-up {
+	@include icon(arrow-up);
+}

--- a/Assets/src/css/modules/_responsive-tabs.scss
+++ b/Assets/src/css/modules/_responsive-tabs.scss
@@ -40,8 +40,7 @@ $tabPanelTextColor: black;
 	padding: em(9, (context: 18));
 	position: relative;
 
-	&:after {
-		content: $iconArrowDown;
+	@include icon(arrow-down, after) {
 		display: block;
 		@include font-size(32);
 		@extend %icon-config;
@@ -67,9 +66,8 @@ $tabPanelTextColor: black;
 		color: $tabActiveTextColor;
 		margin-bottom: 0;
 
-		&:after {
+		@include icon(arrow-up, after) {
 			color: $tabActiveTextColor;
-			content: $iconArrowUp;
 		}
 	}
 }
@@ -80,9 +78,8 @@ $tabPanelTextColor: black;
 		color: $tabActiveTextColor;
 		margin-bottom: 0;
 
-		&:after {
+		@include icon(arrow-up, after) {
 			color: $tabActiveTextColor;
-			content: $iconArrowUp;
 		}
 	}
 	.responsive-tabs__heading:hover {

--- a/Assets/src/css/variables/_all.scss
+++ b/Assets/src/css/variables/_all.scss
@@ -1,8 +1,8 @@
 @import "grid";
 @import "breakpoints";
-
 @import "colors";
 @import "folders";
+@import "icons";
 @import "measurements";
 @import "options";
 @import "placeholders";

--- a/Assets/src/css/variables/_icons.scss
+++ b/Assets/src/css/variables/_icons.scss
@@ -1,0 +1,11 @@
+// Icon font variables map
+// @param $icons {Map} Icon font values mapped to named keys
+
+$icons: (
+	arrow-down: "\e600",
+	arrow-up: "\e601",
+	checkbox-checked: "\e602",
+	checkbox-unchecked: "\e603",
+	radio-checked: "\e604",
+	radio-unchecked: "\e605",
+);

--- a/Assets/src/css/variables/_typography.scss
+++ b/Assets/src/css/variables/_typography.scss
@@ -11,4 +11,5 @@ $baseFontSize: 16;
 $baseFontPercentage: percentage($baseFontSize / 16);
 $lineHeight: 1.5;
 $baseFontFamily: 'Source Sans Pro', Helvetica, Arial, sans-serif;
+$iconFontFamily: 'icomoon';
 $listBulletSize: 24;


### PR DESCRIPTION
Converts icon variables to use a map and adds a new function and mixin to make usage easier.

This could use some discussion, but: this PR moves the icon variable declarations to `/variables/icons`, since they don't really make sense in defaults anymore (they're essentially core pieces). Likewise, the two specific icon declarations have been moved into a new `module/icons`.

I did leave the actual defaults for icons in `base/defaults`, though I renamed the existing `icon()` mixin to `icon-config()`, since that's all it is and it can get changed to a placeholder once we drop IE8 support.

The icon function and mixin both are largely the examples referenced in #118 from Eric Suzanne, though I've added some optional variables to the mixin both for which pseudo element and which icon map to use. I also added a warning message to the function similar to what we have in the color() function.

I've also updated the few instance of existing icon font variable usage to use the new mixin.