### PR TITLE
Release 2.3.1: ¡Adiós!

### DIFF
--- a/Assets/src/package.json
+++ b/Assets/src/package.json
@@ -33,7 +33,7 @@
 	"gulp-sourcemaps": "~1.5.2",
 	"gulp-uglify": "~1.1.0",
 	"gulp-util": "~3.0.4",
-	"jquery": "~2.1.3",
+	"jquery": "~> 3.0.0",
 	"merge-stream": "~0.1.6",
 	"multimatch": "^2.0.0",
 	"rimraf": "~2.2.8",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
+# **This project is no longer being actively maintained. If you have some fixes, please feel free to open a PR.**
+   
+   
 ![Phoenix](Assets/src/img/content/logo-placeholder.png)
 ===================
+
 Phoenix represents what we use at Connective DX for the basis of new projects. With a library of patterns ready at our fingertips, a powerful and flexible grid system, and a clean, modular organization, you don't need to reinvent the wheel. And you'll have more time to invent the next wheel.
 
 # Documentation


### PR DESCRIPTION
* updates jQuery dependency due to potential security issue
* adds repo not maintained messaging in README

![sad beep](https://bukk.it/sadbeep.gif)